### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/mirage-kv-mem.opam
+++ b/mirage-kv-mem.opam
@@ -22,7 +22,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.05.0"}
-  "dune" {build}
+  "dune"
   "alcotest" {with-test}
   "ppx_deriving" {with-test}
   "mirage-clock" {>= "2.0.0"}


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.