### PR TITLE
use dune variants, preserve timestamp function in type t

### DIFF
--- a/mirage-kv-mem.opam
+++ b/mirage-kv-mem.opam
@@ -24,11 +24,10 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "1.3.0"}
   "alcotest" {with-test}
-  "mirage-clock" {>= "3.0.0"}
+  "mirage-ptime" {>= "4.0.0"}
   "mirage-kv" {>= "6.0.0"}
   "fmt"
   "ptime"
-  "mirage-clock-unix" {>= "3.0.0"}
   "optint"
 ]
 conflicts: [ "result" {< "1.5"} ]

--- a/mirage-kv-mem.opam
+++ b/mirage-kv-mem.opam
@@ -24,11 +24,11 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "dune" {>= "1.3.0"}
   "alcotest" {with-test}
-  "mirage-ptime" {>= "4.0.0"}
+  "mirage-ptime" {>= "5.0.0"}
   "mirage-kv" {>= "6.0.0"}
-  "fmt"
-  "ptime"
-  "optint"
+  "fmt" {>= "0.9.0"}
+  "ptime" {>= "1.1.0"}
+  "optint" {>= "0.3.0"}
 ]
 conflicts: [ "result" {< "1.5"} ]
 

--- a/src/dune
+++ b/src/dune
@@ -1,4 +1,4 @@
 (library
   (name mirage_kv_mem)
   (public_name mirage-kv-mem)
-  (libraries mirage-kv fmt ptime mirage-clock optint))
+  (libraries mirage-kv fmt ptime mirage-ptime optint))

--- a/src/mirage_kv_mem.ml
+++ b/src/mirage_kv_mem.ml
@@ -205,82 +205,72 @@ module Pure = struct
 
 end
 
-module Make (CLOCK : Mirage_clock.PCLOCK) = struct
-  type key = Mirage_kv.Key.t
+type key = Mirage_kv.Key.t
 
-  [@@@warning "-34"]
-  type nonrec error = error
-  let pp_error = pp_error
+let now () = Mirage_ptime.now ()
 
-  [@@@warning "-34"]
-  type nonrec write_error = write_error
-  let pp_write_error = pp_write_error
+let connect () = Lwt.return (ref (Pure.empty (now ()) ()))
+let disconnect _t = Lwt.return ()
 
-  let now () = Ptime.v (CLOCK.now_d_ps ())
+type t = Pure.t ref
 
-  let connect () = Lwt.return (ref (Pure.empty (now ()) ()))
-  let disconnect _t = Lwt.return ()
+let last_modified dict key =
+  Lwt.return @@ Pure.last_modified !dict key
 
-  type t = Pure.t ref
+let digest dict key =
+  Lwt.return @@ match Pure.get_node !dict key with
+  | Ok (Value (_, data)) -> Ok (Digest.string data)
+  | Ok (Dictionary (mtime, dict)) ->
+    let data = Fmt.to_to_string Pure.pp (Dictionary (mtime, dict)) in
+    Ok (Digest.string data)
+  | Error e -> Error e
 
-  let last_modified dict key =
-    Lwt.return @@ Pure.last_modified !dict key
+let exists dict key =
+  Lwt.return @@ match Pure.get_node !dict key with
+  | Ok (Value _) -> Ok (Some `Value)
+  | Ok (Dictionary _) -> Ok (Some `Dictionary)
+  | Error (`Not_found _) -> Ok None
+  | Error e -> Error e
 
-  let digest dict key =
-    Lwt.return @@ match Pure.get_node !dict key with
-    | Ok (Value (_, data)) -> Ok (Digest.string data)
-    | Ok (Dictionary (mtime, dict)) ->
-      let data = Fmt.to_to_string Pure.pp (Dictionary (mtime, dict)) in
-      Ok (Digest.string data)
-    | Error e -> Error e
+let get dict key = Lwt.return @@ Pure.get !dict key
 
-  let exists dict key =
-    Lwt.return @@ match Pure.get_node !dict key with
-    | Ok (Value _) -> Ok (Some `Value)
-    | Ok (Dictionary _) -> Ok (Some `Dictionary)
-    | Error (`Not_found _) -> Ok None
-    | Error e -> Error e
+let get_partial dict key ~offset ~length =
+  Lwt.return @@ Pure.get_partial !dict key ~offset ~length
 
-  let get dict key = Lwt.return @@ Pure.get !dict key
+let size dict key = Lwt.return @@ Pure.size !dict key
 
-  let get_partial dict key ~offset ~length =
-    Lwt.return @@ Pure.get_partial !dict key ~offset ~length
+let remove dict key = Lwt.return @@ match Pure.remove !dict key (now ()) with
+  | Error e -> Error e
+  | Ok dict' -> dict := dict'; Ok ()
 
-  let size dict key = Lwt.return @@ Pure.size !dict key
+let list dict key = Lwt.return @@ Pure.list !dict key
 
-  let remove dict key = Lwt.return @@ match Pure.remove !dict key (now ()) with
+let set dict key data = Lwt.return @@ match Pure.set !dict key (now ()) data with
+  | Error e -> Error e
+  | Ok dict' -> dict := dict'; Ok ()
+
+let set_partial dict key ~offset data =
+  Lwt.return @@ match Pure.set_partial !dict key (now ()) ~offset data with
+  | Error e -> Error e
+  | Ok dict' -> dict := dict'; Ok ()
+
+let rename dict ~source ~dest =
+  Lwt.return @@ match Pure.rename !dict ~source ~dest (now ()) with
+  | Error e -> Error e
+  | Ok dict' -> dict := dict'; Ok ()
+
+let pp fmt dict = Pure.pp fmt !dict
+
+let equal a b = Pure.equal !a !b
+
+let allocate dict key ?last_modified size =
+  let open Lwt.Infix in
+  exists dict key >|= function
+  | Error _ as e -> e
+  | Ok Some _ -> Error (`Already_present key)
+  | Ok None ->
+    let data = String.make (Optint.Int63.to_int size) '\000' in
+    let now = Option.value ~default:(now ()) last_modified in
+    match Pure.set !dict key now data with
     | Error e -> Error e
     | Ok dict' -> dict := dict'; Ok ()
-
-  let list dict key = Lwt.return @@ Pure.list !dict key
-
-  let set dict key data = Lwt.return @@ match Pure.set !dict key (now ()) data with
-    | Error e -> Error e
-    | Ok dict' -> dict := dict'; Ok ()
-
-  let set_partial dict key ~offset data =
-    Lwt.return @@ match Pure.set_partial !dict key (now ()) ~offset data with
-    | Error e -> Error e
-    | Ok dict' -> dict := dict'; Ok ()
-
-  let rename dict ~source ~dest =
-    Lwt.return @@ match Pure.rename !dict ~source ~dest (now ()) with
-    | Error e -> Error e
-    | Ok dict' -> dict := dict'; Ok ()
-
-  let pp fmt dict = Pure.pp fmt !dict
-
-  let equal a b = Pure.equal !a !b
-
-  let allocate dict key ?last_modified size =
-    let open Lwt.Infix in
-    exists dict key >|= function
-    | Error _ as e -> e
-    | Ok Some _ -> Error (`Already_present key)
-    | Ok None ->
-      let data = String.make (Optint.Int63.to_int size) '\000' in
-      let now = Option.value ~default:(now ()) last_modified in
-      match Pure.set !dict key now data with
-      | Error e -> Error e
-      | Ok dict' -> dict := dict'; Ok ()
-end

--- a/src/mirage_kv_mem.mli
+++ b/src/mirage_kv_mem.mli
@@ -25,7 +25,6 @@ include Mirage_kv.RW
   with type write_error := write_error
    and type error := error
 
-val connect : unit -> t Lwt.t
+val connect : ?now:(unit -> Ptime.t) -> unit -> t Lwt.t
 val pp : t Fmt.t
 val equal : t -> t -> bool
-val set_last_modified : t -> Ptime.t option -> unit

--- a/src/mirage_kv_mem.mli
+++ b/src/mirage_kv_mem.mli
@@ -28,3 +28,4 @@ include Mirage_kv.RW
 val connect : unit -> t Lwt.t
 val pp : t Fmt.t
 val equal : t -> t -> bool
+val set_last_modified : t -> Ptime.t option -> unit

--- a/src/mirage_kv_mem.mli
+++ b/src/mirage_kv_mem.mli
@@ -1,8 +1,6 @@
 type error = Mirage_kv.error
-val pp_error : error Fmt.t
 
 type write_error = Mirage_kv.write_error
-val pp_write_error : write_error Fmt.t
 
 module Pure : sig
   type t
@@ -23,15 +21,10 @@ module Pure : sig
   val pp : t Fmt.t
 end
 
-module Make (Clock : Mirage_clock.PCLOCK) : sig
-  type nonrec error = error
-  type nonrec write_error = write_error
+include Mirage_kv.RW
+  with type write_error := write_error
+   and type error := error
 
-  include Mirage_kv.RW
-    with type write_error := write_error
-     and type error := error
-
-  val connect : unit -> t Lwt.t
-  val pp : t Fmt.t
-  val equal : t -> t -> bool
-end
+val connect : unit -> t Lwt.t
+val pp : t Fmt.t
+val equal : t -> t -> bool


### PR DESCRIPTION
~~I'm not yet 100% sure about the `set_last_modified`, and will look into `crunch` once more how to retain its semantics (which currently embeds a Mirage_clock.PCLOCK with a hardcoded timestamp).~~

Other options include to have a timestamp (or a `unit -> Ptime.t`) in `connect`, which may be more suitable. That can be an optional parameter and default to `Mirage_ptime.now ()`.

EDIT: the above has been implemented now.